### PR TITLE
Update TrackDetailsView.vue

### DIFF
--- a/src/views/TrackDetailsView.vue
+++ b/src/views/TrackDetailsView.vue
@@ -206,7 +206,7 @@ td {
 
 .country-flag {
   border: thin solid darkgrey;
-  height: 16px;
+  width: 23px;
   margin-bottom: 1px;
 }
 


### PR DESCRIPTION
Matching country flags on width instead of height.
It's nicer visually when flags match on width, because they're on rows. It'd be fine matching them on height if they were in columns.